### PR TITLE
Replace cout with LOGE for logging exceptions

### DIFF
--- a/Source/LSLInletThread.cpp
+++ b/Source/LSLInletThread.cpp
@@ -69,11 +69,11 @@ bool LSLInletThread::updateBuffer()
     }
     catch (const std::runtime_error &re)
     {
-        std::cout << "Failed to read data samples with runtime error: " << re.what() << std::endl;
+        LOGE("Failed to read data samples with runtime error: ", re.what());
     }
     catch (const std::exception &ex)
     {
-        std::cout << "Failed to read data samples with exception: " << ex.what() << std::endl;
+        LOGE("Failed to read data samples with runtime exception: ", ex.what());
     }
 
     if (multiplexed_samples_read <= 0)
@@ -177,11 +177,11 @@ void LSLInletThread::readMarkers(std::size_t samples_to_read)
     }
     catch (const std::runtime_error &re)
     {
-        std::cout << "Failed to read markers with runtime error: " << re.what() << std::endl;
+        LOGE("Failed to read markers with runtime error: ", re.what());
     }
     catch (const std::exception &ex)
     {
-        std::cout << "Failed to read markers with exception: " << ex.what() << std::endl;
+        LOGE("Failed to read markers with exception: ", ex.what());
     }
 }
 
@@ -407,12 +407,12 @@ bool LSLInletThread::setMarkersMappingPath(std::string filePath)
     }
     catch (const std::runtime_error &re)
     {
-        std::cout << "Failed to read markers mapping file with runtime error: " << re.what() << std::endl;
+        LOGE("Failed to read markers mapping file with runtime error: ", re.what());
         return false;
     }
     catch (const std::exception &ex)
     {
-        std::cout << "Failed to read markers mapping file with exception: " << ex.what() << std::endl;
+        LOGE("Failed to read markers mapping file with runtime exception: ", ex.what());
         return false;
     }
 


### PR DESCRIPTION
This PR replaces uses of `cout` with `LOGE` in the exception handlers.